### PR TITLE
Made outputDevice and audioDevice options consistent with documentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,8 @@ mpg321.prototype.file = function file() {
 // options requiring next argument
 each({
   // there options have long name and short name.
-  'outputdevice': '-o',
-  'audiodevice' : '-a',
+  'outputDevice': '-o',
+  'audioDevice' : '-a',
   'gain'        : '-g',
   'skip'        : '-k',
   'frames'      : '-n',


### PR DESCRIPTION
Added a capital to 'device' in outputDevice and audioDevice options to be consistent with the documentation (Readme)
